### PR TITLE
fix: update actions ref with ratchet

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ runs:
   using: composite
   steps:
     - name: Setup python
-      uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # ratchet:actions/setup-python@v4
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # ratchet:actions/setup-python@v5
       with:
         python-version-file: ${{ inputs.python-version-file }}
         python-version: ${{ inputs.python-version }}
@@ -36,7 +36,7 @@ runs:
       shell: bash
       run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
     - name: Cache pip dependencies
-      uses: actions/cache@2f8e54208210a422b2efd51efaa6bd6d7ca8920f # ratchet:actions/cache@v3
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # ratchet:actions/cache@v4
       id: cache-pip
       with:
         path: ${{ steps.pip-cache-dir.outputs.dir }}

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ runs:
   using: composite
   steps:
     - name: Setup python
-      uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # ratchet:actions/setup-python@v4
+      uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # ratchet:actions/setup-python@v4
       with:
         python-version-file: ${{ inputs.python-version-file }}
         python-version: ${{ inputs.python-version }}
@@ -36,7 +36,7 @@ runs:
       shell: bash
       run: echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
     - name: Cache pip dependencies
-      uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # ratchet:actions/cache@v3
+      uses: actions/cache@2f8e54208210a422b2efd51efaa6bd6d7ca8920f # ratchet:actions/cache@v3
       id: cache-pip
       with:
         path: ${{ steps.pip-cache-dir.outputs.dir }}


### PR DESCRIPTION
The pinned version of `actions/cache` is actually deprecated by github, resulting on the following error: 
```{bash}
This request has been automatically failed because it uses a deprecated version of actions/cache: 88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8.
Please update your workflow to use v3/v4 of actions/cache to avoid interruptions.
Learn more: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down
```

This PR updates the version `actions/setup-python` and `actions/cache` using ratchet according to the constraints.